### PR TITLE
Added possibility to provide extra HTTP headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+venv/
+.idea/

--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ optional arguments:
                      detection
   --port PORT        opens port for SSRF detection
   --workers WORKERS  number of parallel workers
+  -H [HEADER [HEADER ...]], --header [HEADER [HEADER ...]]
+                     extra http headers to attach
 ```
 
 #### Usage


### PR DESCRIPTION
Hi,

I'd like to propose this extra functionality.

I wanted to use aem-hacker on our non-public AEM servers, which have an extra security layer using ADFS. To be able to get passed that, I needed the option to add some HTTP extra headers and cookies to every request. So I implemented `-H <header>` options as in curl.

You can then grab the needed data from f.e. Chrome devtools, copy to curl, and copy/paste the required `-H` options to aem-hacker and execute all tests.

Furthermore, I fixed some small Python errors, fixed some line length issues and added debug logging to requests to be able to see what aem-hacker is doing.

I hope you like it. If it needs some extra work, I'm happy to help.

Thank you very much for this amazing toolkit!

Kind regards

Wim