### PR TITLE
Prevent extra headers to override script defined headers

### DIFF
--- a/aem_hacker.py
+++ b/aem_hacker.py
@@ -115,7 +115,14 @@ def http_request(url, method='GET', data=None, additional_headers=None, proxy=No
     if additional_headers:
         headers.update(additional_headers)
     if extra_headers:
-        headers.update(extra_headers)
+        
+        headers.update({ 
+            # Retrieve the headers configured as extra headers but not controlled
+            # by the application in this specific request
+            h_name: h_value 
+            for h_name, h_value in extra_headers.items()
+            if h_name not in headers
+            })
 
     if not proxy:
         proxy = {}
@@ -136,11 +143,17 @@ def http_request_multipart(url, method='POST', data=None, additional_headers=Non
     if additional_headers:
         headers.update(additional_headers)
     if extra_headers:
-        headers.update(extra_headers)
+        headers.update({ 
+            # Retrieve the headers configured as extra headers but not controlled
+            # by the application in this specific request
+            h_name: h_value 
+            for h_name, h_value in extra_headers.items()
+            if h_name not in headers
+            })
 
     if not proxy:
         proxy = {}
-
+    
     if debug:
         print('>> Sending {} {}'.format(method, url))
 


### PR DESCRIPTION
The goal of this PR is to give precedence to the headers defined by the aem_hacker script over the extra headers passed as command line arguments.

In some scenario the user might need to configure the 'Authorization' header because his target environment is protected with basic authentication, for example.

The aem_hacker scripts also need to configure that header for some checks, aiming to test the configuration with default credentials.

If the user defined headers are used those checks are not effective