### PR TITLE
Create iterable string list in by_siren_api function

### DIFF
--- a/aem_discoverer.py
+++ b/aem_discoverer.py
@@ -341,7 +341,8 @@ def by_siren_api(base_url, debug, proxy=None):
     SIREN = itertools.product(('/api/content.json', ),
                               ('', '.css', '.js', '.ico', '.png', '/test.css', '/test.html', '/test.ico', '/test.1.json',
                                '/test...4.2.1...json', ';%0a.css', ';%0aa.html', ';%0aa.ico', '?a.css', '?a.html', '?a.ico'))
-
+    SIREN = list('{0}{1}'.format(p1, p2) for p1, p2 in SIREN)
+    
     for path in SIREN:
         url = normalize_url(base_url, path)
 


### PR DESCRIPTION
The by_siren_api is missing the formatted list creation step which is causing the discoverer to iterate through a tuple instead of a string list. This is causing an error in the normalize_url function