### PR TITLE
Fix case where cookies need to be set by visiting URL once before

### DIFF
--- a/aem_hacker.py
+++ b/aem_hacker.py
@@ -116,29 +116,37 @@ def error(message, **kwargs):
 
 
 def http_request(url, method='GET', data=None, additional_headers=None, proxy=None, debug=False):
-    headers = {'User-Agent': 'curl/7.30.0'}
-    if additional_headers:
-        headers.update(additional_headers)
-    if extra_headers:
+
+    with requests.Session() as session:
+        headers = {'User-Agent': 'curl/7.30.0'}
+        if additional_headers:
+            headers.update(additional_headers)
+        if extra_headers:
         
-        headers.update({ 
-            # Retrieve the headers configured as extra headers but not controlled
-            # by the application in this specific request
-            h_name: h_value 
-            for h_name, h_value in extra_headers.items()
-            if h_name not in headers
+            headers.update({
+                # Retrieve the headers configured as extra headers but not controlled
+                # by the application in this specific request
+                h_name: h_value
+                for h_name, h_value in extra_headers.items()
+                if h_name not in headers
             })
 
-    if not proxy:
-        proxy = {}
+        if not proxy:
+            proxy = {}
 
-    if debug:
-        print('>> Sending {} {}'.format(method, url))
+        if debug:
+            print('>> Sending {} {}'.format(method, url))
 
-    resp = requests.request(method, url, data=data, headers=headers, proxies=proxy, verify=False, timeout=40, allow_redirects=False)
+        session.get(url, verify=False, timeout=40, allow_redirects=False)
+        if method == 'GET':
+            resp = session.get(url, data=data, headers=headers, proxies=proxy, verify=False, timeout=40, allow_redirects=False)
+        elif method == 'POST':
+            resp = session.post(url, data=data, headers=headers, proxies=proxy, verify=False, timeout=40, allow_redirects=False)
+        else:
+            print(f'UNHANDLED METHOD {method}')
 
-    if debug:
-        print('<< Received HTTP-{}', resp.status_code)
+        if debug:
+            print('<< Received HTTP-{}', resp.status_code)
 
     return resp
 


### PR DESCRIPTION
This worked in my case and thought I'd contribute it back into the main repo. There's probably a better way to do this. Essentially the cookies are set when visiting the URL once, then we do the request again with the needed cookies. Without the cookies, the response was always 302.